### PR TITLE
[cron] run a system cron job inside the nextcloud image

### DIFF
--- a/charts/nextcloud/Chart.yaml
+++ b/charts/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nextcloud
-version: 4.3.6
+version: 4.3.7
 appVersion: 27.1.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/charts/nextcloud/README.md
+++ b/charts/nextcloud/README.md
@@ -51,7 +51,7 @@ We also package the following helm charts from Bitnami for you to _optionally_ u
 
 - Kubernetes 1.24+
 - Persistent Volume provisioner support in the underlying infrastructure
-- Helm >=3.7.0 ([for subchart scope exposing](nextcloud/helm#152))
+- Helm >=3.7.0 ([for subchart scope exposing](https://github.com/nextcloud/helm/pull/152))
 
 ## Installing the Chart
 
@@ -154,6 +154,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `redis.auth.existingSecret`                                | The name of an existing secret with Redis® credentials                                       | `''`                       |
 | `redis.auth.existingSecretPasswordKey`                     | Password key to be retrieved from existing secret                                            | `''`                       |
 | `cronjob.enabled`                                          | Whether to enable/disable cron jobs sidecar                                                  | `false`                    |
+| `cronjob.asSidecar`                                        | Run cronjob as sidecar `true`or inside the main pod `false`                                  | `true`                     |
 | `cronjob.lifecycle.postStartCommand`                       | Specify deployment lifecycle hook postStartCommand for the cron jobs sidecar                 | `nil`                      |
 | `cronjob.lifecycle.preStopCommand`                         | Specify deployment lifecycle hook preStopCommand for the cron jobs sidecar                   | `nil`                      |
 | `cronjob.resources`                                        | CPU/Memory resource requests/limits for the cron jobs sidecar                                | `{}`                       |

--- a/charts/nextcloud/templates/deployment.yaml
+++ b/charts/nextcloud/templates/deployment.yaml
@@ -56,6 +56,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: {{ include "nextcloud.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if and .Values.cronjob.enabled (not .Values.cronjob.asSidecar) }}
+        command:
+          - "/bin/sh"
+          - "-c"
+          - "busybox crond -l 0 -L /dev/stdout ; /entrypoint.sh apache2-foreground"
+        {{- end }}
         {{- if .Values.lifecycle }}
         lifecycle:
         {{-   if .Values.lifecycle.postStartCommand }}
@@ -131,7 +137,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "nextcloud.volumeMounts" . | trim | nindent 8 }}
-      {{- if .Values.cronjob.enabled }}
+      {{- if and .Values.cronjob.enabled .Values.cronjob.asSidecar }}
       - name: {{ .Chart.Name }}-cron
         image: {{ include "nextcloud.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/nextcloud/values.yaml
+++ b/charts/nextcloud/values.yaml
@@ -348,7 +348,10 @@ redis:
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron
 ##
 cronjob:
-  enabled: false
+  enabled: true
+  # If set to `true` the cron will run inside a side-car container
+  # If set to `false` it will run in the same container as the nextcloud server
+  asSidecar: true
 
   ## Cronjob sidecar resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Instead of running the cron as a sidecar, with this change the cron can run inside the main container by setting `cronjob.asSidecar=false`. Default will stay `true` for backwards compatability.

# Pull Request

## Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

## Benefits

<!-- What benefits will be realized by the code change? -->

## Possible drawbacks

<!-- Describe any known limitations with your change -->

## Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

## Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

## Checklist <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] DCO has been [signed off on the commit](https://docs.github.com/en/github/authenticating-to-github/signing-commits).
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (optional) Variables are documented in the README.md
